### PR TITLE
#85 Made sure the "Back to catalog" button is shown in landscape orientation

### DIFF
--- a/app/src/androidTest/java/de/lebenshilfe_muenster/uk_gebaerden_muensterland/sign_browser/video/SignVideoTest.java
+++ b/app/src/androidTest/java/de/lebenshilfe_muenster/uk_gebaerden_muensterland/sign_browser/video/SignVideoTest.java
@@ -103,8 +103,13 @@ public class SignVideoTest {
 
     @Test
     public void checkManualBackButtonNavigatesToSignBrowser() {
-        onView(ViewMatchers.withText(getStringResource(R.string.back_to_sign_browser))).check(matches(isDisplayed())).perform(click());
-        onView(ViewMatchers.withText(getStringResource(R.string.sign_browser))).check(matches(isDisplayed()));
+        clickManualBackButton();
+    }
+
+    @Test
+    public void checkManualBackButtonNavigatesToSignBrowserInLandscapeOrientation() {
+        onView(isRoot()).perform(orientationLandscape());
+        clickManualBackButton();
     }
 
     /**
@@ -121,11 +126,6 @@ public class SignVideoTest {
         checkVideoIsLoadingAndPlaying();
     }
 
-    @Test
-    public void checkControlInfoTextIsPresent() {
-        onView(withText(getStringResource(R.string.clickVideoToShowControls))).check(matches(isDisplayed()));
-    }
-
     /**
      * This test is disabled by default because it is meant to check the error message which is
      * displayed when a video cannot be loaded. This is difficult to mock. It can be tested by
@@ -134,7 +134,7 @@ public class SignVideoTest {
      */
     //@Test
     public void checkErrorMessageIsDisplayedWhenVideoCannotBeLoaded() {
-        // setup - navigate back to sign browser as @before method navigates to sign viewer
+        // setup - navigate back to sign browser as @Before method navigates to sign viewer
         checkUpButtonNavigatesToSignBrowserInternal();
         // do the test
         final String missingSignName = "Dann/Danach";
@@ -142,7 +142,6 @@ public class SignVideoTest {
         onView(allOf(withText(missingSignName))).check(matches(isDisplayed())).perform(click());
         onView(allOf(withId(R.id.signVideoName), withText(getStringResource(R.string.videoError)))).check(matches(isDisplayed()));
         onView(allOf(withId(R.id.signVideoView))).check(matches(not(isDisplayed())));
-        onView(allOf(withId(R.id.clickVideoToShowControls))).check(matches(not(isDisplayed())));
         onView(allOf(withId(R.id.signVideoExceptionMessage), withText(getStringResource(R.string.ASVF_1)))).check(matches(isDisplayed()));
         onView(withId(R.id.signVideoLoadingProgressCircle)).check(matches(not((isDisplayed()))));
         onView(allOf(withId(R.id.backToSignBrowserButton), withText(getStringResource(R.string.back_to_sign_browser)))).check(matches(isDisplayed()));
@@ -159,6 +158,10 @@ public class SignVideoTest {
         onView(ViewMatchers.withText(R.string.sign_browser)).check(matches(isDisplayed()));
     }
 
+    private void clickManualBackButton() {
+        onView(ViewMatchers.withText(getStringResource(R.string.back_to_sign_browser))).check(matches(isDisplayed())).perform(click());
+        onView(ViewMatchers.withText(getStringResource(R.string.sign_browser))).check(matches(isDisplayed()));
+    }
 
     private void videoIsLoadingAndPlaying() {
         onView(allOf(withId(R.id.signVideoName), withText(MAMA))).check(matches(isDisplayed()));

--- a/app/src/main/java/de/lebenshilfe_muenster/uk_gebaerden_muensterland/sign_browser/video/SignVideoFragment.java
+++ b/app/src/main/java/de/lebenshilfe_muenster/uk_gebaerden_muensterland/sign_browser/video/SignVideoFragment.java
@@ -41,7 +41,6 @@ public class SignVideoFragment extends AbstractSignVideoFragment {
     private TextView signVideoName;
     private TextView signVideoMnemonic;
     private TextView signVideoExceptionMessage;
-    private TextView clickVideoToShowControls;
     private Button backToSignBrowserButton;
 
     @Nullable
@@ -53,7 +52,6 @@ public class SignVideoFragment extends AbstractSignVideoFragment {
         this.videoView = (VideoView) view.findViewById(R.id.signVideoView);
         this.signVideoMnemonic = (TextView) view.findViewById(R.id.signVideoMnemonic);
         this.signVideoExceptionMessage = (TextView) view.findViewById(R.id.signVideoExceptionMessage);
-        this.clickVideoToShowControls = (TextView) view.findViewById(R.id.clickVideoToShowControls);
         this.backToSignBrowserButton = (Button) view.findViewById(R.id.backToSignBrowserButton);
         this.backToSignBrowserButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -79,7 +77,6 @@ public class SignVideoFragment extends AbstractSignVideoFragment {
         } catch (VideoSetupException ex) {
             this.signVideoName.setText(getString(R.string.videoError));
             this.signVideoMnemonic.setVisibility(View.GONE);
-            this.clickVideoToShowControls.setVisibility(View.GONE);
             this.signVideoExceptionMessage.setText(ex.getMessage());
             this.signVideoExceptionMessage.setVisibility(View.VISIBLE);
             this.progressBar.setVisibility(View.GONE);

--- a/app/src/main/res/layout/video_fragment_view.xml
+++ b/app/src/main/res/layout/video_fragment_view.xml
@@ -30,30 +30,16 @@
         android:layout_below="@id/signVideoView"
         android:layout_centerHorizontal="true"
         android:layout_gravity="center"
-        android:layout_marginBottom="6dip"
         android:layout_marginTop="6dip"
         android:textAppearance="?android:attr/textAppearanceSmall" />
 
-    <TextView
-        android:id="@+id/clickVideoToShowControls"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/signVideoMnemonic"
-        android:layout_centerHorizontal="true"
-        android:layout_gravity="center"
-        android:layout_marginBottom="6dip"
-        android:layout_marginTop="6dip"
-        android:ellipsize="marquee"
-        android:maxLines="1"
-        android:text="@string/clickVideoToShowControls"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <TextView
         android:id="@+id/signVideoExceptionMessage"
         android:visibility="gone"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/clickVideoToShowControls"
+        android:layout_below="@+id/signVideoMnemonic"
         android:layout_centerHorizontal="true"
         android:layout_gravity="center"
         android:layout_marginTop="6dip"
@@ -67,10 +53,9 @@
         android:layout_gravity="center"
         android:layout_below="@+id/signVideoExceptionMessage"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="6dip"
         android:ellipsize="marquee"
-        android:maxLines="1"
-        android:text="@string/back_to_sign_browser" />
+        android:text="@string/back_to_sign_browser"
+        android:singleLine="true" />
 
     <ProgressBar
         android:id="@+id/signVideoLoadingProgressCircle"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,10 +32,9 @@
     <string name="questionWasHard">Schwer</string>
     <string name="answer">Antwort</string>
     <string name="trainerMnemonic">Eselbrücke</string>
-    <string name="versionName">Version: 1.1.1</string>
+    <string name="versionName">Version: 1.2.0-BETA</string>
     <string name="progress">Fortschritt</string>
     <string name="signTrainerExplanation">\'Einfach\': Lernfortschritt +1, \'Schwer\': -1.</string>
-    <string name="clickVideoToShowControls">Für Steuerung Video anklicken.</string>
     <string name="action_toggle_learning_mode">Modus wechseln</string>
     <string name="howDoesThisSignLookLike">Wie sieht die Gebärde aus?</string>
     <string name="sign_trainer_passive">Gebärden-Trainer (Passiv)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,10 +31,9 @@
     <string name="questionWasHard">Hard</string>
     <string name="answer">Answer</string>
     <string name="trainerMnemonic">mnemomic</string>
-    <string name="versionName">Version: 1.1.1</string>
+    <string name="versionName">Version: 1.2.0-BETA</string>
     <string name="howHardWasTheQuestion">This question was…</string>
     <string name="signTrainerExplanation">\'Easy\': learning progress +1, \'Hard\': -1.</string>
-    <string name="clickVideoToShowControls">Click video to show controls.</string>
     <string name="action_toggle_learning_mode">Toggle mode</string>
     <string name="howDoesThisSignLookLike">How does this sign look like?</string>
     <string name="sign_trainer_passive">Sign trainer passive</string>


### PR DESCRIPTION
#85 Made sure the "Back to catalog" button is shown in landscape orientation by removing the "Click the video to show controls" text label. Will add a replay button instead, see #63.